### PR TITLE
Only interact with drop_down if drop_down_index > 0

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -30,12 +30,13 @@ def login(browser: webdriver,
     # Fill out form and login
     user_field.send_keys(username)
     password_field.send_keys(password)
-    drop_down.click()
+    if drop_down_index > 0:
+        drop_down.click()
 
-    # Press the down arrow drop_down_index times to reach the desired item
-    for _ in range(drop_down_index):
-        drop_down.send_keys(Keys.ARROW_DOWN)
-    drop_down.send_keys(Keys.ENTER)
+        # Press the down arrow drop_down_index times to reach the desired item
+        for _ in range(drop_down_index):
+            drop_down.send_keys(Keys.ARROW_DOWN)
+        drop_down.send_keys(Keys.ENTER)
     login_button.click()
 
 


### PR DESCRIPTION
I had configured you-know-what-company's-ases-url?ClientNo=06 as `ASES_URL` and `LOGIN_DROP_DOWN_INDEX: 0` but the script crashed with "WebDriverException: Message: element not interactable" because the drop down is disabled/grayed out if Ases is opened with that URL.

This fix only tries to interact with drop_down if an index > 0 is given.

This allows for slightly faster login requiring less interaction.